### PR TITLE
add Jenkins exception

### DIFF
--- a/susetest/python/susetest.py
+++ b/susetest/python/susetest.py
@@ -17,6 +17,43 @@ STARTMODE="auto"
 IPADDR="@IPADDR@"
 '''
 
+
+# this exception, is needed to show red balls in jenkins, instead of yellow,
+# because yellow balls in jenkins are defined as unstable tests,
+# and we want to show red balls, when test fail.
+# USAGE in the run(main with susetest) :
+
+# (1):  in the testcase
+#
+#     status = node.run("cat /etc/salt/minion_id")
+#        if not (status):
+#                journal.failure("error minion_id file doesn't exist")
+#                raise susetest.SlenkinsError(1)
+#
+# (2): in the main control execution of the testsuite:
+# try :
+#       my_susetest(server)
+#       really_nice_test(client)
+#       .. testcases(n+1)
+#
+# except  susetest.SlenkinsError as e:      # here we catch the exception and make the exit for jenkins.
+#        journal.writeReport()
+#        sys.exit(e.code)
+#
+# except:
+#        print "Unexpected error:", sys.exc_info()[0]
+#        journal.error("Oops, caught unexpected exception")
+#        journal.info(traceback.format_exc(None))
+#        raise
+#
+#
+
+class SlenkinsError(Exception):
+                def __init__(self, code):
+                        self.code = code
+                def __str__(self):
+                        return repr(self.code)
+
 class ConfigWrapper():
 	def __init__(self, name, data):
 		self.name = name


### PR DESCRIPTION
This commit want to add a new exception, to make compatible
the return status of each testcases with Jenkins.
In this way, we can execute susetest/python api, and give a red ball in case
of failure. At moment, without this, suite is on Jenkins "ustable" = yellow.
