### PR TITLE
[WIP]:Feature/assert fail equal

### DIFF
--- a/susetest/python/susetest.py
+++ b/susetest/python/susetest.py
@@ -10,6 +10,7 @@ import suselog
 import twopence
 import time
 import re
+import sys
 
 ifcfg_template = '''
 BOOTPROTO="static"
@@ -17,42 +18,21 @@ STARTMODE="auto"
 IPADDR="@IPADDR@"
 '''
 
-
-# this exception, is needed to show red balls in jenkins, instead of yellow,
-# because yellow balls in jenkins are defined as unstable tests,
-# and we want to show red balls, when test fail.
-# USAGE in the run(main with susetest) :
-
-# (1):  in the testcase
-#
-#     status = node.run("cat /etc/salt/minion_id")
-#        if not (status):
-#                journal.failure("error minion_id file doesn't exist")
-#                raise susetest.SlenkinsError(1)
-#
-# (2): in the main control execution of the testsuite:
-# try :
-#       my_susetest(server)
-#       really_nice_test(client)
-#       .. testcases(n+1)
-#
-# except  susetest.SlenkinsError as e:      # here we catch the exception and make the exit for jenkins.
-#        journal.writeReport()
-#        sys.exit(e.code)
-#
-# except:
-#        print "Unexpected error:", sys.exc_info()[0]
-#        journal.error("Oops, caught unexpected exception")
-#        journal.info(traceback.format_exc(None))
-#        raise
-#
-#
-
+# This class is needed for break a whole testsuite, exit without run all tests. Wanted in some scenarios.
+# Otherwise we can use susetest.finish(journal) to continue after  failed tests, 
 class SlenkinsError(Exception):
                 def __init__(self, code):
                         self.code = code
                 def __str__(self):
                         return repr(self.code)
+
+# finish the junit report.
+def finish(journal):
+        journal.writeReport()
+        if (journal.num_failed() + journal.num_errors()):
+                        sys.exit(1)
+        sys.exit(0)
+
 
 class ConfigWrapper():
 	def __init__(self, name, data):
@@ -107,12 +87,6 @@ def Config(name, **kwargs):
 	raise exceptions.RuntimeError("unable to create a valid config object")
 	return None
 
-def finish(journal):
-	if journal:
-		journal.writeReport()
-		if journal.num_failed() + journal.num_errors():
-			exit(1)
-	exit(0)
 
 class Target(twopence.Target):
 	def __init__(self, name, config):

--- a/susetest/python/susetest.py
+++ b/susetest/python/susetest.py
@@ -26,6 +26,27 @@ class SlenkinsError(Exception):
                 def __str__(self):
                         return repr(self.code)
 
+def assert_fail_equal(node, command, expected, exit_code):
+        ''' this function catch the output of command and expect a result string
+        it check that a command fail with something as string.'''
+        journal.beginTest("For command \"{}\" is expected \"{}\" ".format(command, expected))
+
+        status = node.run(command)
+        if (status):
+                journal.failure("COMMAND SHOULD FAIL but is not! !!{}".format(command))
+                return False
+        # check code exit of command.
+        if (status.code != exit_code):
+                journal.failure("COMMAND returned \"{}\" EXPECTED \"{}\"".format(str(status.code), str(exit_code)) )
+        # check output of failed command.
+        s = str(status.stdout)
+        if  (expected in s):
+                journal.success("ASSERT_TEST_FAILURE_EQUAL for {} PASS! OK".format(command))
+                return True
+        else :
+           journal.failure("GOT \"{}\",  EXPECTED\"{}\"".format(s, expected))
+           return False
+
 # finish the junit report.
 def finish(journal):
         journal.writeReport()


### PR DESCRIPTION
Hi Olaf,

i would like to propose a function like "assert_fail_equal" for susetest.py api.

This function can check the exit_code and the string of failed command.

I saw already some similar implementation in one of your testsuite, i think tcpd use something similar.

Implementation is already done, see pr.

The function itself ,  does not work  in the susetest.py, but on the "run.py".
 I wanted  to show you, because  I have this function on the run.py of testsuite, and i think is a nice general function for testing-api, not susetest(api).

So i was thinking 2 things:
- make a new file/lib like susetest-api (testing-api) that depends from susetest.py : assert_fail_equal, etc etc.
  - susetest will rest the core of the api.
- Or  try to integrate the function according the syntax you use on susetest.py, and to use the specifics functions. I saw that there, you don't use journal.failure etc directly.

What do you think ? thanks in advance.

Best regards
