### PR TITLE
'&' is forbidden in JUnit XML attributes

### DIFF
--- a/minixml/library/xml-writer.c
+++ b/minixml/library/xml-writer.c
@@ -291,7 +291,7 @@ xml_escape_quote(const char *string)
 	while ((cc = *string++) != '\0') {
 		if (cc == '"' || cc == '<' || cc == '>')
 			cc = '\'';
-		else if (cc == '\\')
+		else if (cc == '\\' || cc == '&')
 			cc = '/';
 		*s++ = cc;
 	}


### PR DESCRIPTION
In XML, '&' normally introduces entities, no matter whether in text or in attributes.

If someone does
<code>  journal.beginTest("alpha && omega")</code>

suselog will create
<code> &lt; ... testcase name="alpha && omega" ... &gt;</code>

which is invalid XML, because '&&' is not a valid entity. Better change it to any other character, like '/'.
