### PR TITLE
Enable attributes:  node.ext_ip (cloud) && node.family

### DIFF
--- a/susetest/python/susetest.py
+++ b/susetest/python/susetest.py
@@ -37,7 +37,7 @@ def finish(journal):
 class ConfigWrapper():
 	def __init__(self, name, data):
 		self.name = name
-		self.data = data;
+		self.data = data
 
 		# Set the workspace
 		self.workspace = self.data.workspace()
@@ -60,6 +60,9 @@ class ConfigWrapper():
 
 	def ipv4_address(self, nodename):
 		return self.data.node_internal_ip(nodename)
+
+	def ipv4_ext(self, nodename):
+		return self.data.node_external_ip(nodename)
 
 	def ipv6_address(self, nodename):
 		try:
@@ -106,6 +109,9 @@ class Target(twopence.Target):
 		# Backward compat
 		self.ipaddr = self.ipv4_addr
 		self.ip6addr = self.ipv6_addr
+
+                # external ip for cloud
+                self.ipaddr_ext = config.ipv4_ext(self.name)
 
 		self.__syslogSize = -1
 


### PR DESCRIPTION
### What does this PR do?

Enable the external.ip attribute for node.

```
print (server.ipaddr_ext)
```

External_ip == internal_ip  when run test locally.

Motivation: 
I need this variable for testing a testsuite suse-manager  in cloud. 
### What issues does this PR fix or reference (if it fix any issues) ?

it fix a a semicolon ";"
### Previous Behavior ( if applicable)

node.ipaddr_ext = None
### New Behavior (if applicable)

node.ipaddr_ext = 10.10.*
### Tests written? ( unit-test for new-feature/PR, units-test for susetest_api, etc. )

Tested locally, work. 

Signed-off-by: Dario Maiocchi dmaiocchi@suse.com
