### PR TITLE
Enable famile attribute for node

### DIFF
--- a/susetest/python/susetest.py
+++ b/susetest/python/susetest.py
@@ -112,6 +112,19 @@ class Target(twopence.Target):
 
                 # external ip for cloud
                 self.ipaddr_ext = config.ipv4_ext(self.name)
+  		self.family = self.get_family()
+
+	def get_family(self):
+                ''' get_family return a string : 42.1(leap), 12.2, 12.1, 11.4 for  sles etc. '''
+                status = self.run("grep VERSION_ID /etc/os-release | cut -c13- | head -c -2 ", quiet=True)
+                if not status:
+                        self.logError("cannot get os-release family")
+                        return None
+                family = str(status.stdout)
+                if not family:
+                        self.logError("cannot get os-release strings")
+                        return None
+                return family
 
 		self.__syslogSize = -1
 

--- a/susetest/python/susetest_api/assertions.py
+++ b/susetest/python/susetest_api/assertions.py
@@ -41,13 +41,17 @@ def assert_ok_equal(node, command, expected):
                 node.journal.failure("GOT Output:\"{}\",  EXPECTED\"{}\"".format(s, expected))
 	        return False
 
-# assert_fail_equal(sut, "zypper lifecycle IAM_NOT_EXISTING_PACKAGE;", 2 "SKIP")
+# assert_fail_equal(sut, "zypper in IAM_NOT_EXISTING_PACKAGE;", 2 ,"SKIP")
+# assert_fail_equal(sut, "zypper in IAM_NOT_EXISTING_PACKAGE;", 2 ,"HI I'M FAILING MESSAGE")
 def assert_fail_equal(node, command, code,  expected="SKIP"):
         ''' this function catch the output of failed command and expect a result string
         it check that a command fail with something as string.
 	by default we don't check the string returned by cmd, only the return_code'''
 
-        node.journal.beginTest("For failed command \"{}\" is expected \"{}\" ".format(command, expected))
+	if ( expected != "SKIP"):
+      		  node.journal.beginTest("command \"{}\" should fail with this err Mess \"{}\" and errcode \"{}\" ".format(command, expected, code))
+	else : 
+		  node.journal.beginTest("command \"{}\" should fail with retcode : \"{}\"".format(command, code))
         if ( type(code) is str):
                 node.journal.fatal("please insert a integer for variable code !")
         status = node.run(command)


### PR DESCRIPTION
### What does this PR do?

Enable attribute for node like server.family or client.family

node.family -> 12.1 , flag = quiet

Signed-off-by: Dario Maiocchi dmaiocchi@suse.com
