### PR TITLE
Add versioncmp function

### DIFF
--- a/susetest/python/susetest_api/system.py
+++ b/susetest/python/susetest_api/system.py
@@ -5,6 +5,8 @@ import suselog
 # needed by install_pkg 
 from pipes import quote
 from susetest_api.assertions import run_cmd
+# needed by versioncmp
+import re
 
 
 # Thx to Aurelian Aptel, Samba Dev.
@@ -21,6 +23,35 @@ def install_pkg(node, package):
         # type error
         raise susetest.SlenkinsError(1)
     run_cmd(node, "zypper -n --gpg-auto-import-keys ref && zypper -n in %s" % package, "installing package")
+
+
+# Compares the version of package installed on node
+# Example:
+# ret = versioncmp(host, "shadow", "4.2.1")
+# if ret == "<": # meaning if installed version is older than 4.2.1
+def versioncmp(node, package, version):
+    status = node.run("rpm -qi " + package, quiet=True)
+    if status.code == 1:
+        node.journal.fail("rpm -qi " + package + "failed")
+        return
+
+    line = str(status.stdout)
+    installed_version = re.findall(r"Version +: (.+?)\n", line)[0]
+
+    if installed_version:
+        status = node.run("zypper versioncmp " + installed_version + " " + version, quiet=True)
+        if status != 0:
+            node.journal.fail("zypper versioncmp failed")
+            return
+
+        comparison = str(status.stdout)
+
+        if "matches" in comparison:
+            return "="
+        elif "newer" in comparison:
+            return ">"
+        elif "older" in comparison:
+            return "<"
 
 ## EASY-HACKS
 


### PR DESCRIPTION
### What does this PR do?

adds a new function `versioncmp` which compares the version of an installed package with what is provided to the function.
It returns either `<` for older `>` for newer or `=` for the same.
